### PR TITLE
Sermon Author

### DIFF
--- a/includes/admin/admin-sermon-fields.php
+++ b/includes/admin/admin-sermon-fields.php
@@ -331,6 +331,13 @@ function ctc_sermon_columns_content( $column ) {
 			echo ctc_admin_term_list( $post->ID, 'ctc_sermon_speaker' );
 
 			break;
+		
+		// Authors
+		case 'ctc_sermon_authors' :
+
+			echo ctc_admin_term_list( $post->ID, 'ctc_sermon_author' );
+
+			break;
 
 	}
 

--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -47,7 +47,7 @@ function ctc_register_post_type_sermon() {
 			'feeds'			=> ctc_feature_supported( 'sermons' )
 		),
 		'supports' 		=> array( 'title', 'editor', 'excerpt', 'publicize', 'thumbnail', 'comments', 'author', 'revisions' ), // 'editor' required for media upload button (see Meta Boxes note below about hiding)
-		'taxonomies' 	=> array( 'ctc_sermon_topic', 'ctc_sermon_book', 'ctc_sermon_series', 'ctc_sermon_speaker', 'ctc_sermon_tag' ),
+		'taxonomies' 	=> array( 'ctc_sermon_topic', 'ctc_sermon_book', 'ctc_sermon_series', 'ctc_sermon_author', 'ctc_sermon_speaker', 'ctc_sermon_tag' ),
 		'menu_icon'		=> 'dashicons-video-alt3'
 	);
 	$args = apply_filters( 'ctc_post_type_sermon_args', $args ); // allow filtering

--- a/includes/taxonomies.php
+++ b/includes/taxonomies.php
@@ -7,7 +7,7 @@
  * @copyright  Copyright (c) 2013 - 2015, churchthemes.com
  * @link       https://github.com/churchthemes/church-theme-content
  * @license    http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- * @since      0.9
+ * @since      0.9x
  */
 
 // No direct access
@@ -16,6 +16,54 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**********************************
  * SERMON TAXONOMIES
  **********************************/
+
+/**
+ * Sermon Author
+ *
+ * @since 0.9x
+ */
+function ctc_register_taxonomy_sermon_author() {
+
+	// Arguments
+	$args = array(
+		'labels' => array(
+			'name' 							=> _x( 'Sermon Author', 'taxonomy general name', 'church-theme-content' ),
+			'singular_name'					=> _x( 'Sermon Author', 'taxonomy singular name', 'church-theme-content' ),
+			'search_items' 					=> _x( 'Search Authors', 'sermons', 'church-theme-content' ),
+			'popular_items' 				=> _x( 'Popular Authors', 'sermons', 'church-theme-content' ),
+			'all_items' 					=> _x( 'All Authors', 'sermons', 'church-theme-content' ),
+			'parent_item' 					=> null,
+			'parent_item_colon' 			=> null,
+			'edit_item' 					=> _x( 'Edit Author', 'sermons', 'church-theme-content' ),
+			'update_item' 					=> _x( 'Update Author', 'sermons', 'church-theme-content' ),
+			'add_new_item' 					=> _x( 'Add Author', 'sermons', 'church-theme-content' ),
+			'new_item_name' 				=> _x( 'New Author', 'sermons', 'church-theme-content' ),
+			'separate_items_with_commas' 	=> _x( 'Separate authors with commas', 'sermons', 'church-theme-content' ),
+			'add_or_remove_items' 			=> _x( 'Add or remove authors', 'sermons', 'church-theme-content' ),
+			'choose_from_most_used' 		=> _x( 'Choose from the most used authors', 'sermons', 'church-theme-content' ),
+			'menu_name' 					=> _x( 'Authors', 'sermon menu name', 'church-theme-content' )
+		),
+		'hierarchical'	=> false, // category-style instead of tag-style
+		'public' 		=> ctc_taxonomy_supported( 'sermons', 'ctc_sermon_author' ),
+		'rewrite' 		=> array(
+			'slug' 			=> 'sermon-author',
+			'with_front' 	=> false,
+			'hierarchical' 	=> true
+		)
+	);
+	$args = apply_filters( 'ctc_taxonomy_sermon_author_args', $args ); // allow filtering
+
+	// Registration
+	register_taxonomy(
+		'ctc_sermon_author',
+		'ctc_sermon',
+		$args
+	);
+
+}
+
+add_action( 'init', 'ctc_register_taxonomy_sermon_author' );
+
 
 /**
  * Sermon topic


### PR DESCRIPTION
Updated plugin to support sermon author as well as speaker.

Many churches will have an elder read a sermon prepared by a pastor from another church, because they do not have a pastor of their own, or for other reasons.

Having the ability to add both to the sermon archives would be ideal.

I've been able to add the author to the sermon, but I can't seem to make the "sermon-author" archive work with the exodus theme.